### PR TITLE
Designate text regions to be spellchecked

### DIFF
--- a/queries/xit/highlights.scm
+++ b/queries/xit/highlights.scm
@@ -1,19 +1,21 @@
-(headline) @XitHeadline
 (open_checkbox) @XitOpenCheckbox
 (checked_checkbox) @XitCheckedCheckbox
 (ongoing_checkbox) @XitOngoingCheckbox
 (obsolete_checkbox) @XitObsoleteCheckbox
 (in_question_checkbox) @XitInQuestionCheckbox
-(open_task (description (main_line) @XitOpenTaskMainLine))
-(open_task (description (indent (other_line) @XitOpenTaskOtherLine)))
-(checked_task (description (main_line) @XitCheckedTaskMainLine))
-(checked_task (description (indent (other_line) @XitCheckedTaskOtherLine)))
-(ongoing_task (description (main_line) @XitOngoingTaskMainLine))
-(ongoing_task (description (indent (other_line) @XitOngoingTaskOtherLine)))
-(obsolete_task (description (main_line) @XitObsoleteTaskMainLine))
-(obsolete_task (description (indent (other_line) @XitObsoleteTaskOtherLine)))
-(in_question_task (description (main_line) @XitInQuestionTaskMainLine))
-(in_question_task (description (indent (other_line) @XitInQuestionTaskOtherLine)))
+[
+  (headline) @XitHeadline
+  (open_task (description (main_line) @XitOpenTaskMainLine))
+  (open_task (description (indent (other_line) @XitOpenTaskOtherLine)))
+  (checked_task (description (main_line) @XitCheckedTaskMainLine))
+  (checked_task (description (indent (other_line) @XitCheckedTaskOtherLine)))
+  (ongoing_task (description (main_line) @XitOngoingTaskMainLine))
+  (ongoing_task (description (indent (other_line) @XitOngoingTaskOtherLine)))
+  (obsolete_task (description (main_line) @XitObsoleteTaskMainLine))
+  (obsolete_task (description (indent (other_line) @XitObsoleteTaskOtherLine)))
+  (in_question_task (description (main_line) @XitInQuestionTaskMainLine))
+  (in_question_task (description (indent (other_line) @XitInQuestionTaskOtherLine)))
+] @spell
 (open_task (description (priority) @XitOpenTaskPriority))
 (checked_task (description (priority) @XitCheckedTaskPriority))
 (ongoing_task (description (priority) @XitOngoingTaskPriority))


### PR DESCRIPTION
Test:
1. Open features.xit
2. Enable spellchecking (`:set spell`)
3. Press <kbd>]</kbd><kbd>s</kbd> and <kbd>[</kbd><kbd>s</kbd> to jump between misspelled words

Before this commit, there will be no spelling errors shown
With this change, all text in headlines and task lines are spellchecked